### PR TITLE
Fix swapped registration and login challenge timeouts

### DIFF
--- a/src/models/secure-passkeys-challenge.php
+++ b/src/models/secure-passkeys-challenge.php
@@ -23,9 +23,9 @@ class Secure_Passkeys_Challenge extends Secure_Passkeys_Model
         $fingerprint = Secure_Passkeys_Helper::generate_fingerprint();
 
         if ($challenge_type === 'registration') {
-            $minutes = intval(Secure_Passkeys_Helper::get_option('login_timeout', 5));
-        } else {
             $minutes = intval(Secure_Passkeys_Helper::get_option('registration_timeout', 5));
+        } else {
+            $minutes = intval(Secure_Passkeys_Helper::get_option('login_timeout', 5));
         }
 
         $date = (new DateTime())->add(new DateInterval('PT' . $minutes . 'M'));


### PR DESCRIPTION
Thanks for the great work!

I did an audit and it looks like in generate_challenge the challenge_type registration used login_timeout and vice versa. This corrects each challenge type to use its own configured timeout option.